### PR TITLE
Visual Fixes

### DIFF
--- a/robo_soccer_platform/assets/js/app.js
+++ b/robo_soccer_platform/assets/js/app.js
@@ -27,7 +27,13 @@ let Hooks = {};
 
 Hooks.JoyStick = {
   mounted() {
-    const joy = new JoyStick(this.el.id)
+    const joy = new JoyStick(
+      this.el.id, 
+      {
+        internalFillColor: this.el.dataset.inner_joystick_color,
+        internalStrokeColor: this.el.dataset.outer_joystick_color
+      }
+    )
     const view = this;
 
     let intervalId;

--- a/robo_soccer_platform/assets/js/joystick.js
+++ b/robo_soccer_platform/assets/js/joystick.js
@@ -43,7 +43,7 @@
   *  internalLineWidth {Int} (optional) - Border width of Stick (Default value is 2)
   *  internalStrokeColor {String}(optional) - Border color of Stick (Default value is '#003300')
   *  externalLineWidth {Int} (optional) - External reference circonference width (Default value is 2)
-  *  externalStrokeColor {String} (optional) - External reference circonference color (Default value is '#008000')
+  *  externalStrokeColor {String} (optional) - External reference circonference color (Default value is '#000000')
   *  autoReturnToCenter {Bool} (optional) - Sets the behavior of the stick, whether or not, it should return to zero position when released (Default value is True and return to zero)
   * @param callback {StickStatus} - 
   */
@@ -57,7 +57,7 @@
          internalLineWidth = (typeof parameters.internalLineWidth === "undefined" ? 2 : parameters.internalLineWidth),
          internalStrokeColor = (typeof parameters.internalStrokeColor === "undefined" ? "#003300" : parameters.internalStrokeColor),
          externalLineWidth = (typeof parameters.externalLineWidth === "undefined" ? 2 : parameters.externalLineWidth),
-         externalStrokeColor = (typeof parameters.externalStrokeColor ===  "undefined" ? "#008000" : parameters.externalStrokeColor),
+         externalStrokeColor = (typeof parameters.externalStrokeColor ===  "undefined" ? "#000000" : parameters.externalStrokeColor),
          autoReturnToCenter = (typeof parameters.autoReturnToCenter === "undefined" ? true : parameters.autoReturnToCenter);
  
      callback = callback || function(StickStatus) {};

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
@@ -171,7 +171,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
         Drużyna <%= if @color == :red, do: "czerwona", else: "zielona" %> (<%= @players_number_display %>)
       </div>
       <div class={"flex flex-col px-8 py-8 #{@container_class}"}>
-        <div class={"flex flex-col grow-0 shrink-0 basis-52 gap-2 #{@container_class} overflow-auto"}>
+        <div class={"flex flex-col grow-0 shrink-0 basis-96 gap-2 #{@container_class} overflow-auto"}>
           <div :for={player <- @players} class="flex bg-sky-blue gap-4">
             <.player player={player} game_stopped?={@game_stopped?}/>
           </div>

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
@@ -170,9 +170,11 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
       <div class={"text-center #{@class} bg-light-orange p-2"}>
         Drużyna <%= if @color == :red, do: "czerwona", else: "zielona" %> (<%= @players_number_display %>)
       </div>
-      <div class={"flex flex-1 flex-col px-8 py-8 gap-2 #{@container_class}"}>
-        <div :for={player <- @players} class="flex bg-sky-blue gap-4">
-          <.player player={player} game_stopped?={@game_stopped?}/>
+      <div class={"flex flex-col px-8 py-8 #{@container_class}"}>
+        <div class={"flex flex-col grow-0 shrink-0 basis-52 gap-2 #{@container_class} overflow-auto"}>
+          <div :for={player <- @players} class="flex bg-sky-blue gap-4">
+            <.player player={player} game_stopped?={@game_stopped?}/>
+          </div>
         </div>
       </div>
     </div>

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
@@ -67,6 +67,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
           <.teams
             red_players={@teams["red"].player_inputs}
             green_players={@teams["green"].player_inputs}
+            game_stopped?={@game_state == :stopped}
           />
         </div>
 
@@ -127,6 +128,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
 
   attr :red_players, :list, required: true
   attr :green_players, :list, required: true
+  attr :game_stopped?, :boolean, default: false
 
   defp teams(assigns) do
     ~H"""
@@ -136,12 +138,14 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
         color={:red}
         class="rounded-tl-3xl"
         container_class="rounded-bl-3xl bg-light-red"
+        game_stopped?={@game_stopped?}
       />
       <.team
         players={@green_players}
         color={:green}
         class="rounded-tr-3xl"
         container_class="rounded-br-3xl bg-light-green"
+        game_stopped?={@game_stopped?}
       />
     </div>
     """
@@ -149,6 +153,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
 
   attr :players, :list, required: true
   attr :color, :atom, required: true
+  attr :game_stopped?, :boolean, required: true
   attr :class, :string, default: ""
   attr :container_class, :string, default: ""
 
@@ -167,7 +172,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
       </div>
       <div class={"flex flex-1 flex-col px-8 py-8 gap-2 #{@container_class}"}>
         <div :for={player <- @players} class="flex bg-sky-blue gap-4">
-          <.player player={player} />
+          <.player player={player} game_stopped?={@game_stopped?}/>
         </div>
       </div>
     </div>
@@ -175,11 +180,16 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
   end
 
   attr :player, :map, required: true
+  attr :game_stopped?, :boolean, required: true
 
   defp player(assigns) do
-    direction = Utils.point_to_direction(%{x: assigns.player.x, y: assigns.player.y})
+    direction_icon = if assigns.game_stopped? do
+      "pan_tool"
+    else
+      Utils.point_to_direction(%{x: assigns.player.x, y: assigns.player.y})
+    end
 
-    assigns = assign(assigns, direction: direction)
+    assigns = assign(assigns, direction_icon: direction_icon)
 
     ~H"""
     <div class="flex-1 truncate">
@@ -189,7 +199,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
     </div>
 
     <span class="material-icons-outlined">
-      <%= @direction %>
+      <%= @direction_icon %>
     </span>
     """
   end

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
@@ -153,10 +153,17 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
   attr :container_class, :string, default: ""
 
   defp team(assigns) do
+    players_number_display = case length(assigns.players) do
+      1 -> "1 gracz"
+      number_of_players -> "#{number_of_players} graczy"
+    end
+
+    assigns = assign(assigns, players_number_display: players_number_display)
+
     ~H"""
     <div class="flex flex-col flex-1 min-w-0">
       <div class={"text-center #{@class} bg-light-orange p-2"}>
-        Drużyna <%= if @color == :red, do: "czerwona", else: "zielona" %>
+        Drużyna <%= if @color == :red, do: "czerwona", else: "zielona" %> (<%= @players_number_display %>)
       </div>
       <div class={"flex flex-1 flex-col px-8 py-8 gap-2 #{@container_class}"}>
         <div :for={player <- @players} class="flex bg-sky-blue gap-4">

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/game_dashboard/components.ex
@@ -62,8 +62,10 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
 
     ~H"""
     <div class="flex flex-1">
-      <div class="grid grid-flow-col auto-cols-fr w-full">
-        <div class="flex flex-col flex-1 col-span-2">
+      <div class="grid grid-flow-col auto-cols-fr w-full gap-2">
+        <div class="flex flex-col flex-1 col-span-2 gap-4">
+          <.score red_goals={@teams["red"].goals} green_goals={@teams["green"].goals} />
+          <.directions red_direction={@red_direction} green_direction={@green_direction} />
           <.teams
             red_players={@teams["red"].player_inputs}
             green_players={@teams["green"].player_inputs}
@@ -93,8 +95,6 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
         </div>
         <div class="flex flex-col flex-1 items-center gap-8">
           <.time_left seconds={@seconds_left} />
-          <.score red_goals={@teams["red"].goals} green_goals={@teams["green"].goals} />
-          <.directions red_direction={@red_direction} green_direction={@green_direction} />
         </div>
       </div>
     </div>
@@ -236,13 +236,13 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
     ~H"""
     <div class="bg-white px-4 py-2 text-3xl border border-solid border-black">
       <div class="flex min-w-0">
-        <div class="flex-1 bg-red-500 p-4"></div>
+        <div class="flex-1 bg-light-red p-4"></div>
 
         <div class="flex-1 p-4 flex items-center justify-center text-3xl whitespace-nowrap">
           <%= @red_goals %> : <%= @green_goals %>
         </div>
 
-        <div class="flex-1 bg-green-500 p-4"></div>
+        <div class="flex-1 bg-light-green p-4"></div>
       </div>
     </div>
     """
@@ -255,7 +255,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
     ~H"""
     <div class="bg-white px-4 py-2 text-3xl border border-solid border-black">
       <div class="flex min-w-0">
-        <div class="flex-1 bg-red-500 p-4"></div>
+        <div class="flex-1 bg-light-red p-4"></div>
 
         <div class="flex-1 p-4 flex items-center justify-center text-3xl whitespace-nowrap">
           <span class="material-icons-outlined">
@@ -269,7 +269,7 @@ defmodule RoboSoccerPlatformWeb.GameDashboard.Components do
           </span>
         </div>
 
-        <div class="flex-1 bg-green-500 p-4"></div>
+        <div class="flex-1 bg-light-green p-4"></div>
       </div>
     </div>
     """

--- a/robo_soccer_platform/lib/robo_soccer_platform_web/live/player/steering.ex
+++ b/robo_soccer_platform/lib/robo_soccer_platform_web/live/player/steering.ex
@@ -40,13 +40,33 @@ defmodule RoboSoccerPlatformWeb.Player.Steering do
 
   @impl true
   def render(assigns) do
+    {inner_joystick_color, outer_joystick_color, team_display} = case assigns.player.team do
+      "green" -> {"#00FF1A", "#008A0E", "Drużyna Zielona"}
+      "red" -> {"#FF3737", "#C40000", "Drużyna Czerwona"}
+    end
+
+    assigns =
+      assigns
+      |> assign(inner_joystick_color: inner_joystick_color)
+      |> assign(outer_joystick_color: outer_joystick_color)
+      |> assign(team_display: team_display)
+
     ~H"""
-    <div id="container" phx-hook="Storage">
+    <div class="text-3xl text-center">
+      <%= @team_display %>
+    </div>
+    <div class="text-3xl text-center">
+      <%= @player.username %>
+    </div>
+
+    <div id="container">
       <div
         id="joystick"
         phx-hook="JoyStick"
         phx-update="ignore"
-        class="fixed w-[min(70vw,70vh)] h-[min(70vw,70vh)] left-0 top-0 right-0 bottom-0 m-auto"
+        data-inner_joystick_color={@inner_joystick_color}
+        data-outer_joystick_color={@outer_joystick_color}
+        class={"fixed w-[min(70vw,70vh)] h-[min(70vw,70vh)] left-0 top-0 right-0 bottom-0 m-auto"}
       >
         <!-- joystick will be rendered here -->
       </div>


### PR DESCRIPTION
Following were done:
* Now in player.steering player's username is provided, also the joystick color is in the color of team
* Added display of team size in dashboard
* Players' move status are set to "pan_tool" if game is stopped
* Game score and teams' directions were moved to the left side
* Teams are now scrollable